### PR TITLE
refactor: ui experience adjusts and shadcn aligns

### DIFF
--- a/components/craft/fancy-multi-select.tsx
+++ b/components/craft/fancy-multi-select.tsx
@@ -77,12 +77,12 @@ export function FancyMultiSelect() {
     }
   }, []);
 
-  const selectables = FRAMEWORKS.filter(framework => !selected.includes(framework));
+  const selectables = FRAMEWORKS.filter(framework => !selected.find(s => s.value === framework.value));
 
   return (
     <Command onKeyDown={handleKeyDown} className="overflow-visible bg-transparent">
       <div
-        className="group border border-input px-3 py-2 text-sm ring-offset-background rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+        className="min-h-10 group max-h-32 overflow-auto border border-input px-3 py-2 text-sm ring-offset-background rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
       >
         <div className="flex gap-1 flex-wrap">
           {selected.map((framework) => {
@@ -119,32 +119,32 @@ export function FancyMultiSelect() {
           />
         </div>
       </div>
-      <div className="relative mt-2">
         {open && selectables.length > 0 ?
-          <div className="absolute w-full z-10 top-0 rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
-            <CommandGroup className="h-full overflow-auto">
-              {selectables.map((framework) => {
-                return (
-                  <CommandItem
-                    key={framework.value}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                    onSelect={(value) => {
-                      setInputValue("")
-                      setSelected(prev => [...prev, framework])
-                    }}
-                    className={"cursor-pointer"}
-                  >
-                    {framework.label}
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
+          <div className="relative z-50 translate-y-1">
+              <div className="absolute w-full top-0 rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
+                <CommandGroup className="h-full max-h-80 overflow-auto">
+                  {selectables.map((framework) => {
+                    return (
+                      <CommandItem
+                        key={framework.value}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                        onSelect={() => {
+                          setInputValue("")
+                          setSelected(prev => [...prev, framework])
+                        }}
+                        className={"cursor-pointer"}
+                      >
+                        {framework.label}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </div>
           </div>
           : null}
-      </div>
     </Command >
   )
 }


### PR DESCRIPTION
Thanks for the great component, saved me a lot of time!

While testing the component in a more complex form context I saw somethings that could be improved.
I see that some changes may be too personal, so I will discribe them here so you can decide better what really matters to you:

- Fixed selectables filtering. It is currently comparing objects, it works for static objects like in the component example, but when using states the object comparison gets buggy.
- Adjusted the Input minimun height to match shadcn Input component
- Add maximun height + overflow to selected options box. So that with large lists of selected options it has a better presentation
- Moved the selectables box all inside ternary and changed margin top by translate (just like shadcn does for the Select component). In the current way, with margin top it produces align errors, look:
![multi-select-disalign](https://github.com/mxkaske/mxkaske.dev/assets/38769565/3bb83d56-e2ec-4ce6-bbd8-ff095a979ec1)

- Moved the z-index property to selectables parent box (and increased it to the same value shadcn uses in Select component). For me it was not working with z-index on the child, look:
![multi-select-z-index](https://github.com/mxkaske/mxkaske.dev/assets/38769565/cb9d4616-28d8-49aa-8f12-62e7cc7aa320)

- Add maximun height to CommandGroup box, so large lists of options have a better presentation
- Removed unused "value" prop in CommandItem onSelect() function

That's all. Let me know if made any stupidity.
Thanks again.