### PR TITLE
Fixes `fancy-box.tsx` bugs

### DIFF
--- a/components/craft/fancy-box.tsx
+++ b/components/craft/fancy-box.tsx
@@ -47,9 +47,6 @@ import { DialogClose } from "@radix-ui/react-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-// FIXME: https://twitter.com/lemcii/status/1659649371162419202?s=46&t=gqNnMIjMWXiG2Rbrr5gT6g
-// Removing states would help maybe?
-
 type Framework = Record<"value" | "label" | "color", string>;
 
 const FRAMEWORKS = [
@@ -101,8 +98,8 @@ export function FancyBox() {
 
   const createFramework = (name: string) => {
     const newFramework = {
-      value: name.toLowerCase(),
-      label: name,
+      value: name.toLowerCase().trim(),
+      label: name.trim(),
       color: "#ffffff",
     };
     setFrameworks((prev) => [...prev, newFramework]);
@@ -166,7 +163,11 @@ export function FancyBox() {
               ref={inputRef}
               placeholder="Search framework..."
               value={inputValue}
-              onValueChange={setInputValue}
+               onValueChange={(value) => {
+                setTimeout(() => {
+                  setInputValue(value);
+                }, 0.1);
+              }}
             />
             <CommandGroup className="max-h-[145px] overflow-auto">
               {frameworks.map((framework) => {
@@ -282,19 +283,18 @@ const CommandItemCreate = ({
   frameworks: Framework[];
   onSelect: () => void;
 }) => {
-  const hasNoFramework = !frameworks
-    .map(({ value }) => value)
-    .includes(`${inputValue.toLowerCase()}`);
+   const input = inputValue.toLowerCase();
 
-  const render = inputValue !== "" && hasNoFramework;
+  const render =
+    inputValue !== "" &&
+    !frameworks.some(({ value }) => value === input || value === input.trim());
 
   if (!render) return null;
 
-  // BUG: whenever a space is appended, the Create-Button will not be shown.
   return (
     <CommandItem
       key={`${inputValue}`}
-      value={`${inputValue}`}
+      value={input.includes(" ") ? `:${inputValue}:` : inputValue}
       className="text-xs text-muted-foreground"
       onSelect={onSelect}
     >


### PR DESCRIPTION
# What does this PR fix?
- Appending space bug removes create new button 
- Spamming search input freezes browser tab.

## Notes and Research

### The Freezing
Upon investigating the freezes, I tested with some debounce hooks to see if it fixes the issue, which It did. Testing with different delays it seems like it worked with the most minimal delay (0.1), In the code I am providing, I used a simple `setTimeout` with a delay of 0.1. The risk of a memory leak is very minimal, but I recommend a full-fledged debounce hook with a cleanup function if used in production. This stops the freezing, although it does get a bit laggy if you do end up spamming for quite a while.

### The space bug
The code provided successfully identifies the spaces or whitespace and adds it to the render condition; it also trims out the value if you do have some whitespace, you're still able to add labels with a space and trims it upon creating a new label.


## Demonstration

### Testing spam freezes
https://github.com/mxkaske/mxkaske.dev/assets/78459953/956b3ca4-0cad-46fb-a515-6f096036a4b8

### Testing space bug
https://github.com/mxkaske/mxkaske.dev/assets/78459953/8c456bab-648e-4273-ae4d-e6ba1b0248c8